### PR TITLE
chore: add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,13 @@
+lib
+.eslintcache
+node_modules/
+.editorconfig  
+.eslintrc      
+.gitignore     
+.nvmrc
+.eslintignore  
+.gitattributes 
+.huskyrc       
+commitlint.config.js
+example-config.json
+rollup.config.js


### PR DESCRIPTION
* reduces risk to publish code and build/test infra to everyone
* reduces package size depends on the amount of code in bundle now