### PR TITLE
fix: undo former fix as config requires `onlyCategories`

### DIFF
--- a/example-config.json
+++ b/example-config.json
@@ -8,7 +8,7 @@
     "best-practices": 90,
     "seo": 80
   },
-  "onlyAudits": [
+  "onlyCategories": [
     "performance",
     "accessibility",
     "best-practices",


### PR DESCRIPTION
Cf. https://github.com/GoogleChrome/lighthouse/blob/master/docs/configuration.md#options

Closes: https://github.com/sumcumo/lighthouse-keeper/issues/9