### PR TITLE
fix(recommended): change audit name 'webapp-install-banner'

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -4,7 +4,7 @@ var recommendedOptions = {
   skipAudits: [
     'uses-webp-images',
     'hreflang',
-    'webapp-install-banner',
+    'installable-manifest',
     'without-javascript',
   ],
 };

--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -2,7 +2,7 @@ export default {
   skipAudits: [
     'uses-webp-images',
     'hreflang',
-    'webapp-install-banner',
+    'installable-manifest',
     'without-javascript',
   ],
 }


### PR DESCRIPTION
With [Lighthouse v4](https://github.com/GoogleChrome/lighthouse/releases/tag/v4.0.0) the audit name has changed to 'installable-manifest'